### PR TITLE
remove NativeTlsClientBuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 cache: cargo
 rust:
 - nightly
-- 1.11.0
+- 1.15.0
 script:
 - cargo test


### PR DESCRIPTION
NativeTlsClientBuilder was introduced in
https://github.com/sfackler/hyper-native-tls/pull/7

As discussed in https://github.com/sfackler/hyper-native-tls/issues/9,
this builder is not necessary, because we can already build a
NativeTlsClient from a TlsConnector, since NativeTlsClient implements
From<TlsConnector>.