### PR TITLE
Bump minimum rustc version to 1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 cache: cargo
 rust:
 - nightly
-- 1.15.0
+- 1.17.0
 script:
 - cargo test


### PR DESCRIPTION
The minimum rustc version should be bumped for [unicode-bidi](https://github.com/servo/unicode-bidi/issues/46).