### PR TITLE
Continue the old 0.2.x series and widen the version range of the native-tls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-native-tls"
-version = "0.3.0"
+version = "0.2.5"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 exclude = ["test/*"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ readme = "README.md"
 
 [dependencies]
 antidote = "1.0"
-native-tls = "0.2"
+native-tls = ">= 0.2, < 0.4"
 hyper = "0.10"


### PR DESCRIPTION
Hi, an old codebase of mine is still using reqwest 0.6, the last sync one. I've been hesitant to to change to the async ones for time being, as I'm just maintaining the code and not willing to have a lot of code churn. reqwest 0.6 uses hyper-native-tls 0.2.x for TLS, and because of this, I'm not able to use modern OpenSSL versions, as they require the openssl crate 0.10.x version whereas hyper-native-tls pulls in 0.9.x via native-tls 0.2. Widening supported native-tls version range to include both 0.2 and 0.3 seems to fix this.

I know that 0.2.x hyper-native-tls is old and possibly unsupported, but I was wondering whether it would be possible to widen the version range and publish a patch version bump? My reasoning is that widening the range while keeping the lower range the same should be backwards compatible, as it doesn't force anyone to bump their transitive dependencies if there is another dependency that requires strictly 0.2.x.

Another alternative would be to publish reqwest 0.6.x that depends on hyper-native-tls 0.3.0. I'm unsure which one is more feasible.